### PR TITLE
Cache dependencies using package-lock file

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,12 +8,12 @@ jobs:
       - checkout
       - restore_cache:
           keys: 
-            - dependency-cache-{{ checksum "package.json" }}
+            - dependency-cache-{{ checksum "package-lock.json" }}
       - run:
           name: install
           command: npm install
       - save_cache: 
-          key: dependency-cache-{{ checksum "package.json" }}
+          key: dependency-cache-{{ checksum "package-lock.json" }}
           paths:
             - node_modules
       - run:


### PR DESCRIPTION
CircleCI was not able to restore dependencies from the cache and the checksum was different for restoring as compared to saving.